### PR TITLE
Add instructions for running in IBM Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ This application runs the show and tell pretained model and serves the inference
 1. The default ID/Passwd is admin/time4fun
 
 [Install Python]: https://www.python.org/downloads/
+
+## Run the app in IBM Cloud
+
+1. Log into IBM Cloud
+1. Create a Python Flask app with a unique app name and a unique host name
+1. Go to your workstation, [Install Python][]
+1. cd into this project's root directory
+1. Run `pip install -r requirements.txt` to install the app's dependencies
+1. Run `python concat_chkp.py` to oncatenate the checkpoint chunks
+1. Update `manifest.yml` with your app name and host name
+1. Upload the app to IBM Cloud, as decribed in <https://console.bluemix.net/docs/starters/upload_app.html>
+1. Access the running app in a browser at <https://yourhostname.mybluemix.net/>
+1. The default ID/Passwd is admin/time4fun

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
   memory: 512M
   instances: 1
   domain: mybluemix.net
-  name: im2txt
-  host: im2txt
+  name: yourappname 
+  host: yourhostname
   disk_quota: 1024M
   buildpack: python_buildpack


### PR DESCRIPTION
Add documentation for running in IBM Cloud and change the sample
manifest.yml to match the instructions.